### PR TITLE
Python 2.7 compatibility

### DIFF
--- a/scourgify/cleaning.py
+++ b/scourgify/cleaning.py
@@ -20,6 +20,12 @@ from scourgify.address_constants import (
     PROBLEM_ST_TYPE_ABBRVS,
 )
 
+# Python 2.x compatibility hack
+try:
+    from __builtin__ import unicode as uc_type
+except ImportError:
+    uc_type = str
+
 # Setup
 
 # Constants
@@ -177,11 +183,11 @@ def clean_upper(text,                           # type: Any
     """
     exclude = exclude or []
     # coerce ints etc to str
-    if not isinstance(text, str):  # pragma: no cover
-        text = str(text)
+    if not isinstance(text, uc_type):  # pragma: no cover
+        text = uc_type(text)
     # catch and convert fractions
     text = unicodedata.normalize('NFKD', text)
-    text = text.translate({8260: '/'})
+    text = text.translate({8260: uc_type('/')})
 
     # evaluate string without commas (,) or ampersand (&) to determine if
     # further processing is necessary
@@ -195,7 +201,7 @@ def clean_upper(text,                           # type: Any
                     and ord(char) not in exclude):
                 text = text.translate({ord(char): None})
             elif unicodedata.category(char).startswith('Pd'):
-                text = text.translate({ord(char): '-'})
+                text = text.translate({ord(char): uc_type('-')})
     join_char = ' '
     if strip_spaces:
         join_char = ''

--- a/scourgify/tests/test_address_normalization.py
+++ b/scourgify/tests/test_address_normalization.py
@@ -9,7 +9,12 @@ Unit tests for scourgify.
 
 # Imports from Standard Library
 from collections import OrderedDict
-from unittest import TestCase, mock
+
+try:
+    from unittest import TestCase, mock
+except ImportError:
+    from unittest import TestCase
+    import mock
 
 # Local Imports
 from scourgify import address_constants


### PR DESCRIPTION
I forked your project for a contact deduplication project written in Python 2.7. There is a compatiblilty issue where unicodedata.normalize expects the unicode type in Python 2 and the string type in Python 3. I added a hack to cleaning.py that aliases the unicode or str type/constructor depending upon the Python version used -- try to import the builtin unicode type and if that fails use str.

The changes allow usaddress-scourgify to run under Python 2.7.

All unit tests pass except for test_handle_abnormal_occupancy, but that fails under Python 3 as well.