### PR TITLE
Make `geocoder` an optional dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+UNRELEASED
+------------------
+* BREAKING: Make `geocoder` an optional dependency.
+
 0.2.3 [2020-05-06]
 ------------------
 * Valid OccupancyType bug fix for OccupancyType that is already valid abbreviation

--- a/scourgify/normalize.py
+++ b/scourgify/normalize.py
@@ -32,7 +32,6 @@ from typing import (  # noqa # pylint: disable=unused-import
 )
 
 # Imports from Third Party Modules
-import geocoder
 import usaddress
 
 # Local Imports
@@ -676,10 +675,23 @@ def format_address_record(address: dict) -> str:
     ]
     return address_template.safe_substitute(address=', '.join(addr_parts))
 
+_GEOCODER_ERROR = (
+    "Install the `geocoder` library, eg with `python -m pip install geocoder` "
+    "to use the `get_geocoder_normalized_addr()` function"
+)
+
+def _geocode(s: str):
+    try:
+        import geocoder
+    except ImportError as e:
+        raise ImportError(_GEOCODER_ERROR) from e
+    return geocoder.google(s)
 
 def get_geocoder_normalized_addr(address: dict | str,
                                  addr_keys: [str] = ADDRESS_KEYS) -> dict:
-    """Get geocoder normalized address parsed to dict with addr_keys.
+    f"""Get geocoder normalized address parsed to dict with addr_keys.
+
+    {_GEOCODER_ERROR}
 
     :param address: string or dict-like containing address data
     :param addr_keys: optional list of address keys. standard list of keys will
@@ -691,7 +703,7 @@ def get_geocoder_normalized_addr(address: dict | str,
     if not isinstance(address, str):
         address_line_2 = address.get('address_line_2')
         address = get_addr_line_str(address, addr_parts=addr_keys)
-    geo_resp = geocoder.google(address)
+    geo_resp = _geocode(address)
     if geo_resp.ok and geo_resp.housenumber:
         line2 = geo_resp.subpremise or address_line_2
         geo_addr_dict = {

--- a/scourgify/tests/test_address_normalization.py
+++ b/scourgify/tests/test_address_normalization.py
@@ -696,9 +696,9 @@ class TestAddressNormalizationUtils(TestCase):
             get_addr_line_str(self.address_dict, addr_parts='line1')
 
     @mock.patch(
-        'scourgify.normalize.geocoder'
+        'scourgify.normalize._geocode'
     )
-    def test_get_geocoder_normalized_addr(self, mock_geocoder):
+    def test_get_geocoder_normalized_addr(self, mock_geocode: mock.MagicMock):
         """Test get_geocoder_normalized_addr"""
         geo_addr = mock.MagicMock()
         geo_addr.ok = True
@@ -709,7 +709,7 @@ class TestAddressNormalizationUtils(TestCase):
         geo_addr.state = 'OR'
         geo_addr.postal = '97000'
 
-        mock_geocoder.google.return_value = geo_addr
+        mock_geocode.return_value = geo_addr
 
         address = {
             'address_line_1': '1234 Main',
@@ -720,7 +720,7 @@ class TestAddressNormalizationUtils(TestCase):
         }
         addr_str_return_value = "1234 Main Boring OR 97000"
         get_geocoder_normalized_addr(address)
-        mock_geocoder.google.assert_called_with(addr_str_return_value)
+        mock_geocode.assert_called_with(addr_str_return_value)
 
     def test_get_ordinal_indicator(self):
         """Test get_ordinal_indicator"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ packages = find:
 include_package_data = True
 zip_safe = False
 install_requires =
-	geocoder>=1.22.6
 	usaddress>=0.5.9
 	yaml-config>=0.1.2
 [bdist_wheel]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py37,py38,py39,py310,py311,py312
 
 [testenv]
 setenv =


### PR DESCRIPTION
I am running into https://github.com/DenisCarriere/geocoder/issues/409
caused by geocoder.
This is preventing me from using scourgify at all in newer python versions.
I am not using geocoder, so it shouldn't even be installed.